### PR TITLE
Update index.js to work with coffee script > 1.7.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('coffee-script');
+require('coffee-script/register');
 module.exports = require('./lib/main');


### PR DESCRIPTION
Hey, I don't know much about coffeescript but I had to make this change to be able to use mongo-watch - according to [this](http://stackoverflow.com/questions/4768748/requireing-a-coffeescript-file-from-a-javascript-file-or-repl) stack overflow entry this change is required post coffee 1.7.0.
