### PR TITLE
Move native_parser option to Mongo's DB contructor

### DIFF
--- a/lib/connect.coffee
+++ b/lib/connect.coffee
@@ -1,7 +1,13 @@
 {Server, Db} = require 'mongodb'
 
 module.exports = ({db, host, port, dbOpts, username, password}, done) ->
-  client = new Db db, new Server(host, port, {native_parser: true}), dbOpts
+	# Create a collection of DB options that includes native_parser without
+	# modifying the collection that the caller provided
+	finalDbOpts = {native_parser: true}
+	for key in dbOpts
+		finalDbOpts[key] = dbOpts[key]
+	
+  client = new Db db, new Server(host, port), finalDbOpts
 
   client.open (err) ->
     return done(err) if err


### PR DESCRIPTION
The mongo docs for Server (http://mongodb.github.io/node-mongodb-native/api-generated/server.html) do not list native_parser as an option, but the docs for Db (http://mongodb.github.io/node-mongodb-native/api-generated/db.html) do.

This change moves the native_parser option to the class that is documented to support it.
