### PR TITLE
Authentication by authDB "admin"

### DIFF
--- a/lib/connect.coffee
+++ b/lib/connect.coffee
@@ -8,7 +8,7 @@ module.exports = ({db, host, port, dbOpts, username, password}, done) ->
 
     # authenticate if credentials were provided
     if username? or password?
-      client.authenticate username, password, (err, result) ->
+      client.authenticate username, password, {authdb:'admin'}, (err, result) ->
         done err, client
 
     else


### PR DESCRIPTION
It's not allowed to create users in 'local' DB so, users should be created in 'admin' DB and authenticate using admin as authDB.
