### PR TITLE
Optional conversion of ObjectIDs

### DIFF
--- a/lib/formats.coffee
+++ b/lib/formats.coffee
@@ -1,4 +1,4 @@
-{getDate, walk, convertObjectID} = require './util'
+{getDate} = require './util'
 
 mapOp =
   n: 'noop'
@@ -13,10 +13,6 @@ module.exports =
 
   # something a bit more readable, but preserving the original data
   pretty: (data) ->
-
-    # convert ObjectIDs to strings
-    data = walk data, convertObjectID
-
     timestamp: getDate data.ts
     operation: mapOp[data.op] or data.op
     namespace: data.ns
@@ -27,10 +23,6 @@ module.exports =
 
   # restructure all ops to look like updates
   normal: (data) ->
-
-    # convert ObjectIDs to strings
-    data = walk data, convertObjectID
-
     targetId = (data.o2?._id or data.o?._id)
     delete data.o._id if data.o
 


### PR DESCRIPTION
I have a use case where ObjectIDs should be retained as such, but I want to use the normal format. I could just copy the code, but making it a flag works just fine here. It also reduces the amount of code which is a good thing!

I've added tests which check that the functionality works in both directions as before.
