### PR TITLE
Allow use of mongo-watch without replSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ This watcher ties into the MongoDB replication log (local.oplog.rs) by default, 
 In order to use this you must:
 
 *replication log*
+
 1. Have access to the oplog.  This will not be available on shared DB hosting, as it would reveal everyone else's database transactions to you.
 2. Have replication enabled.  This can be done by starting mongod with the option '--replSet someArbitraryName'.  You must then call `rs.initiate()` from the mongo CLI.
 
 *master log*
+
 1. Have access to the oplog.  This will not be available on shared DB hosting, as it would reveal everyone else's database transactions to you.
 2. Start your mongod as '--master'.
 3. Use: 'new MongoWatch({useMasterOplog:true})'

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ In order to use this you must:
 *replication log*
 
 1. Have access to the oplog.  This will not be available on shared DB hosting, as it would reveal everyone else's database transactions to you.
-2. Have replication enabled.  This can be done by starting mongod with the option '--replSet someArbitraryName'.  You must then call `rs.initiate()` from the mongo CLI.
+2. Have replication enabled.  This can be done by starting mongod with the option `--replSet someArbitraryName`.  You must then call `rs.initiate()` from the mongo CLI.
 
 *master log*
 
 1. Have access to the oplog.  This will not be available on shared DB hosting, as it would reveal everyone else's database transactions to you.
-2. Start your mongod as '--master'.
-3. Use: 'new MongoWatch({useMasterOplog:true})'
+2. Start your mongod as `--master`.
+3. Use: `new MongoWatch({useMasterOplog:true})`
 
 The watcher is fairly low latency and overhead.  On my machine a test with a single insert and watcher takes 20ms.  The cursor used to tail the oplog is being initialized with {awaitdata: true} so the data should be getting pushed from MongoDB's internal mechanism, instead of polling.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Mongo Watch
 
-This watcher ties into the MongoDB replication log (local.oplog.rs) and notifies your watchers any time the data changes.
+This watcher ties into the MongoDB replication log (local.oplog.rs) by default, but you can also tie into local.oplog.$main on a master DB. It then notifies your watchers any time the data changes.
 
 In order to use this you must:
 
+*replication log*
 1. Have access to the oplog.  This will not be available on shared DB hosting, as it would reveal everyone else's database transactions to you.
 2. Have replication enabled.  This can be done by starting mongod with the option '--replSet someArbitraryName'.  You must then call `rs.initiate()` from the mongo CLI.
+
+*master log*
+1. Have access to the oplog.  This will not be available on shared DB hosting, as it would reveal everyone else's database transactions to you.
+2. Start your mongod as '--master'.
+3. Use: 'new MongoWatch({useMasterOplog:true})'
 
 The watcher is fairly low latency and overhead.  On my machine a test with a single insert and watcher takes 20ms.  The cursor used to tail the oplog is being initialized with {awaitdata: true} so the data should be getting pushed from MongoDB's internal mechanism, instead of polling.
 

--- a/lib/getOplogStream.coffee
+++ b/lib/getOplogStream.coffee
@@ -1,11 +1,14 @@
 {getTimestamp} = require './util'
 connect = require './connect'
 
-module.exports = ({host, port, dbOpts, username, password}, done) ->
+module.exports = ({host, port, dbOpts, username, password, useMasterOplog}, done) ->
   connect {db: 'local', host, port, dbOpts, username, password}, (err, oplogClient) =>
     return done new Error "Error connecting to database: #{err}" if err
 
-    oplogClient.collection 'oplog.rs', (err, oplog) ->
+    collection = 'oplog.rs'
+    if useMasterOplog
+      collection = 'oplog.$main'
+    oplogClient.collection collection, (err, oplog) ->
       return done err if err
 
       connOpts =

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -9,6 +9,7 @@ applyDefaults = (options) ->
   options.host or= 'localhost'
   options.dbOpts or= {w: 1}
   options.format or= 'raw'
+  options.useMasterOplog or= false
   options.convertObjectIDs ?= true
   options.onError or= (error) -> console.log 'Error - MongoWatch:', (error?.stack or error)
   options.onDebug or= ->


### PR DESCRIPTION
Why we need this:
- Existing replicaSets
- Use 'mongod --master' and simplify startup (no rs.initiate() required) 

Sorry no branch because it's such a simple feature.
