### PR TITLE
Create replSetServers array without lodash

### DIFF
--- a/lib/connect.coffee
+++ b/lib/connect.coffee
@@ -7,9 +7,7 @@ module.exports = ({db, host, port, dbOpts, username, password, authdb, replicaSe
 
   if replicaSet
     replSetServers = []
-    _(replicaSet).forEach (replicaServer) ->
-      replSetServers.push new Server(replicaServer.host, replicaServer.port)
-      return
+    replSetServers = (new Server(num.host, num.port) for num in replicaSet)
 
     connection = new ReplSetServers(replSetServers)
   else


### PR DESCRIPTION
For some reason, _(replicaSet).forEach wasn't working for me.

This is why I think is better to loop with a native `for`
